### PR TITLE
Mentions #1312

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -32,6 +32,7 @@
 		<ul>
 			<li><a href="https://github.com/systemd/systemd/issues/437">#437: timeX.google.com provide non standard time</a></li>
 			<li><a href="https://github.com/systemd/systemd/issues/1143">#1143: PID1 getting stuck printing "systemd[1]: Time has been changed" continuously</a></li>
+			<li><a href="https://github.com/systemd/systemd/issues/1312">#1312: restarting systemd service on dependency failure</a></li>
 			<li><a href="https://github.com/systemd/systemd/issues/1596">#1596: journalctl -r -n flags incorrectly processed</a></li>
 			<li><a href="https://github.com/systemd/systemd/issues/2402">#2402: Mount efivarfs read-only</a></li>
 			<li><a href="https://github.com/systemd/systemd/issues/2460">#2460: Showing status of service via systemctl is slow (>10s) if disk journal is used</a></li>


### PR DESCRIPTION
https://github.com/systemd/systemd/issues/1312, open since 2015

Apparently when service B depends on service A, and A fails (bringing B down) then recovers, systemd doesn't try to bring A back up according to its recovery configuration.

You had 1 job, systemd.  1 job.