### PR TITLE
Update KISS Linux website

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -82,7 +82,7 @@
 			<li><a href="https://www.pclinuxos.com/"><img src="img/pclinuxos.png" alt="PcLinuxOS" /></a></li>
 			<li><a href="https://www.gobolinux.org/"><img src="img/gobolinux.png" alt="Gobo Linux" /></a></li>
 			<li><a href="https://web.obarun.org/"><img src="img/oberun.png" alt="Oberun" /></a></li>
-			<li><a href="https://k1ss.org"><img src="img/kiss.png" alt="KISS Linux" /></a></li>
+			<li><a href="https://k1sslinux.org"><img src="img/kiss.png" alt="KISS Linux" /></a></li>
 			<li><a href="https://project-trident.org/"><img src="img/trident.png" alt="Project Trident" /></a></li>
 			<li><a href="https://liguros.gitlab.io/"><img src="img/liguros_200x200.png" alt="LiGurOS" /></a></li>
 			<li><a href="https://sulinos.github.io"><img src="img/sulinos.svg" alt="SulinOS" /></a></li>


### PR DESCRIPTION
The creator of KISS Linux hasn't been active for some time, and the project is being maintained by @kiss-community. In the meantime, the old website went inactive and the new one is at https://k1sslinux.org. This PR updates that URL.