### PR TITLE
Add 31init

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -25,6 +25,7 @@
 			<li>Shepherd (<a href="https://www.gnu.org/software/shepherd/">home</a>)</li>
 			<li>finit (<a href="https://troglobit.com/projects/finit/">home</a>)</li>
 			<li>Hummingbird (<a href="https://github.com/Sweets/hummingbird">repo</a>)</li>
+			<li>31init (<a href="https://gitlab.com/tearch-linux/applications-and-tools/31init">repo</a>)</li>
 			<li>uselessd (<a href="https://bitbucket.org/Tarnyko/uselessd/src">repo</a>; inactive)</li>
 			<li>Upstart (<a href="http://upstart.ubuntu.com">home</a>; inactive)</li>
 			<li>InitNG (<a href="https://github.com/initng/initng">repo</a>; inactive)</li>


### PR DESCRIPTION
31init is tearch-linux and sulin new init system. Tearch will replace 31init with systemd...

31init has 31 line of C code and ultra minimal.

https://gitlab.com/tearch-linux/applications-and-tools/31init