### PR TITLE
Add superd to 'List of init daemons'

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -25,6 +25,7 @@
 			<li>Shepherd (<a href="https://www.gnu.org/software/shepherd/">home</a>)</li>
 			<li>finit (<a href="https://troglobit.com/projects/finit/">home</a>)</li>
 			<li>Hummingbird (<a href="https://github.com/Sweets/hummingbird">repo</a>)</li>
+			<li>superd (<a href="https://sr.ht/~craftyguy/superd/">repo</a>)</li>
 			<li>31init (<a href="https://gitlab.com/tearch-linux/applications-and-tools/31init">repo</a>)</li>
 			<li>uselessd (<a href="https://bitbucket.org/Tarnyko/uselessd/src">repo</a>; inactive)</li>
 			<li>Upstart (<a href="http://upstart.ubuntu.com">home</a>; inactive)</li>


### PR DESCRIPTION
It's technically not a `init` daemon (in the traditional sense), but it still can be beneficial for folks looking to replace systemd.