### PR TITLE
Add Dinit

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -26,6 +26,7 @@
 			<li>finit (<a href="https://troglobit.com/projects/finit/">home</a>)</li>
 			<li>Hummingbird (<a href="https://github.com/Sweets/hummingbird">repo</a>)</li>
 			<li>31init (<a href="https://gitlab.com/tearch-linux/applications-and-tools/31init">repo</a>)</li>
+			<li>Dinit (<a href="https://github.com/davmac314/dinit">repo</a>)</li>
 			<li>uselessd (<a href="https://bitbucket.org/Tarnyko/uselessd/src">repo</a>; inactive)</li>
 			<li>Upstart (<a href="http://upstart.ubuntu.com">home</a>; inactive)</li>
 			<li>InitNG (<a href="https://github.com/initng/initng">repo</a>; inactive)</li>


### PR DESCRIPTION
 Dinit is a service monitoring / "init" system. Currently used as the init system for Chimera Linux, and is an init system option for Artix Linux.

* https://github.com/davmac314/dinit