### PR TITLE
Add blog post about Datadog outage

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -40,6 +40,7 @@
 		<h2>What is so bad about systemd?</h2>
 		<p>List of notable bugs and security issues:</p>
 		<ul>
+      <li><a href="https://newsletter.pragmaticengineer.com/p/inside-the-datadog-outage">Datadog outage costing 5 million dollars caused by systemd upgrade</a></li>
 			<li><a href="https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1988119">Widespread outage was caused on Azure, when systemd 237-3ubuntu10.54 was published to the bionic-security pocket (instances could no longer resolve DNS queries, breaking networking)</a></li>
 			<li><a href="https://github.com/systemd/systemd/issues/437">#437: timeX.google.com provide non standard time</a></li>
 			<li><a href="https://github.com/systemd/systemd/issues/1143">#1143: PID1 getting stuck printing "systemd[1]: Time has been changed" continuously</a></li>

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -40,7 +40,7 @@
 		<h2>What is so bad about systemd?</h2>
 		<p>List of notable bugs and security issues:</p>
 		<ul>
-      <li><a href="https://newsletter.pragmaticengineer.com/p/inside-the-datadog-outage">Datadog outage costing 5 million dollars caused by systemd upgrade</a></li>
+			<li><a href="https://newsletter.pragmaticengineer.com/p/inside-the-datadog-outage">Datadog outage costing 5 million dollars caused by systemd upgrade</a></li>
 			<li><a href="https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1988119">Widespread outage was caused on Azure, when systemd 237-3ubuntu10.54 was published to the bionic-security pocket (instances could no longer resolve DNS queries, breaking networking)</a></li>
 			<li><a href="https://github.com/systemd/systemd/issues/437">#437: timeX.google.com provide non standard time</a></li>
 			<li><a href="https://github.com/systemd/systemd/issues/1143">#1143: PID1 getting stuck printing "systemd[1]: Time has been changed" continuously</a></li>


### PR DESCRIPTION
This PR adds a blog post about the March 8, 2023 Datadog outage involving a system upgrade of Ubuntu and systemd.