### PR TITLE
Fixed typo in peppermintos's link

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -153,7 +153,7 @@
                     <li><a href="http://www.tinycorelinux.net/" rel="external" aria-label="Tiny Core Linux"><img src="img/tinycorelinux.png" alt="Tiny Core Linux logo" width="80" height="80" /></a></li>
                     <li><a href="https://chimera-linux.org/" rel="external" aria-label="Chimera Linux"><img src="img/chimera.png" alt="Chimera Linux logo" width="80" height="80" /></a></li>
                     <li><a href="https://nxos.org/" rel="external" aria-label="Nitrux"><img src="img/nitrux.png" alt="Nitrux logo" width="80" height="80" /></a></li>
-                    <li><a href="https://peppermintos.org/" rel="external" aria-label="Peppermint OS"><img src="img/peppermint.svg" alt="Peppermint OS logo" width="80" height="80" /></a></li>
+                    <li><a href="https://peppermintos.com/" rel="external" aria-label="Peppermint OS"><img src="img/peppermint.svg" alt="Peppermint OS logo" width="80" height="80" /></a></li>
                     <li><a href="https://mxlinux.org/" rel="external" aria-label="MX Linux"><img src="img/mx.png" alt="MX Linux logo" width="80" height="80" /></a></li>
                     <li><a href="https://www.openwrt.org/" rel="external" aria-label="OpenWrt"><img src="img/openwrt.png" alt="OpenWrt logo" width="80" height="80" /></a></li>
                 </ul>


### PR DESCRIPTION
peppermintos.com is the current peppermintos website, not peppermintos.org