### PR TITLE
Update KISS Linux link to new GitHub page

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -139,7 +139,7 @@
                     <li><a href="https://www.pclinuxos.com/" rel="external" aria-label="PCLinuxOS"><img src="img/pclinuxos.png" alt="PCLinuxOS logo" width="80" height="80" /></a></li>
                     <li><a href="https://www.gobolinux.org/" rel="external" aria-label="GoboLinux"><img src="img/gobolinux.png" alt="GoboLinux logo" width="80" height="80" /></a></li>
                     <li><a href="https://web.obarun.org/" rel="external" aria-label="Obarun Linux"><img src="img/oberun.png" alt="Obarun Linux logo" width="80" height="80" /></a></li>
-                    <li><a href="https://kisslinux.org" rel="external" aria-label="KISS Linux"><img src="img/kiss.png" alt="KISS Linux logo" width="80" height="80" /></a></li>
+                    <li><a href="https://kisslinux.github.io/" rel="external" aria-label="KISS Linux"><img src="img/kiss.png" alt="KISS Linux logo" width="80" height="80" /></a></li>
                     <li><a href="https://liguros.gitlab.io/" rel="external" aria-label="LiGurOS"><img src="img/liguros_200x200.png" alt="LiGurOS logo" width="80" height="80" /></a></li>
                     <li><a href="https://sulinos.github.io" rel="external" aria-label="SulinOS"><img src="img/sulinos.svg" alt="SulinOS logo" width="80" height="80" /></a></li>
                     <li><a href="https://crux.nu" rel="external" aria-label="CRUX Linux"><img src="img/crux.png" alt="CRUX Linux logo" width="80" height="80" /></a></li>


### PR DESCRIPTION
`https://kisslinux.org/` no longer serves KISS Linux content.